### PR TITLE
Add support for Chinese generic PowerWave Xbox Controller

### DIFF
--- a/Xb2XInput/XboxController.cpp
+++ b/Xb2XInput/XboxController.cpp
@@ -45,7 +45,7 @@ std::vector<std::pair<int, int>> xbox_devices =
   {0x0F30, 0x0202}, // Joytech Advanced Controller
   {0x0F30, 0x8888}, // BigBen XBMiniPad Controller
   {0x102C, 0xFF0C}, // Joytech Wireless Advanced Controller
-  //{0xFFFF, 0xFFFF}, // "Chinese-made Xbox Controller" (disabled since ID seems sketchy)
+  {0xFFFF, 0xFFFF}, // PowerWave Xbox Controller (The ID's may look sketchy but this controller actually uses it)
 };
 
 void USBDeviceChanged(const XboxController& controller, bool added); // from Xb2XInput.cpp

--- a/dist/x64/install drivers.bat
+++ b/dist/x64/install drivers.bat
@@ -61,6 +61,7 @@ wdi-simple --vid 0x0F30 --pid 0x0202 --type 0 --name "Joytech Advanced Controlle
 wdi-simple --vid 0x0F30 --pid 0x8888 --type 0 --name "BigBen XBMiniPad Controller"
 wdi-simple --vid 0x102C --pid 0xFF0C --type 0 --name "Joytech Wireless Advanced Controller"
 wdi-simple --vid 0x0738 --pid 0x4522 --type 0 --name "MadCatz LumiCON"
+wdi-simple --vid 0xFFFF --pid 0xFFFF --type 0 --name "PowerWave Xbox Controller"
 
 echo Driver installation complete!
 :exit

--- a/dist/x86/install drivers.bat
+++ b/dist/x86/install drivers.bat
@@ -61,6 +61,7 @@ wdi-simple --vid 0x0F30 --pid 0x0202 --type 0 --name "Joytech Advanced Controlle
 wdi-simple --vid 0x0F30 --pid 0x8888 --type 0 --name "BigBen XBMiniPad Controller"
 wdi-simple --vid 0x102C --pid 0xFF0C --type 0 --name "Joytech Wireless Advanced Controller"
 wdi-simple --vid 0x0738 --pid 0x4522 --type 0 --name "MadCatz LumiCON"
+wdi-simple --vid 0xFFFF --pid 0xFFFF --type 0 --name "PowerWave Xbox Controller"
 
 echo Driver installation complete!
 :exit


### PR DESCRIPTION
Add support for the Generic chinese xbox controllers, the name "PowerWave Xbox Controller" was taken from the "xbcd.inf" driver file.