### PR TITLE
Add support for Konami DDR Pad

### DIFF
--- a/Xb2XInput/XboxController.hpp
+++ b/Xb2XInput/XboxController.hpp
@@ -58,11 +58,26 @@ struct XboxInputReport {
   OGXINPUT_GAMEPAD Gamepad;
 };
 
+#define XBOX_OUTPUT_REPORT_ID_RUMBLE 0
+#define XBOX_OUTPUT_REPORT_ID_LED 1
+#define LED_ANIMATION_ID_ALL_OFF 0
+#define LED_ANIMATION_ID_ON_1 6
+#define LED_ANIMATION_ID_ON_2 7
+#define LED_ANIMATION_ID_ON_3 8
+#define LED_ANIMATION_ID_ON_4 9
+
+struct XboxOutputReportLED {
+  BYTE bAnimationId;
+};
+
 struct XboxOutputReport {
   BYTE bReportId;
   BYTE bSize;
 
-  OGXINPUT_RUMBLE Rumble;
+  union {
+    OGXINPUT_RUMBLE Rumble;
+    XboxOutputReportLED LED;
+  };
 };
 
 struct Deadzone {

--- a/dist/x64/Drivers/install drivers.bat
+++ b/dist/x64/Drivers/install drivers.bat
@@ -58,6 +58,8 @@ wdi-simple --vid 0x0F30 --pid 0x0202 --type 0 --name "Joytech Advanced Controlle
 wdi-simple --vid 0x0F30 --pid 0x8888 --type 0 --name "BigBen XBMiniPad Controller"
 wdi-simple --vid 0x102C --pid 0xFF0C --type 0 --name "Joytech Wireless Advanced Controller"
 wdi-simple --vid 0x0738 --pid 0x4522 --type 0 --name "MadCatz LumiCON"
+wdi-simple --vid 0x12AB --pid 0x0004 --type 0 --name "Konami DDR Pad"
+wdi-simple --vid 0x12AB --pid 0x8809 --type 0 --name "Konami DDR Pad"
 wdi-simple --vid 0xFFFF --pid 0xFFFF --type 0 --name "PowerWave Xbox Controller"
 
 echo Driver installation complete!

--- a/dist/x86/Drivers/install drivers.bat
+++ b/dist/x86/Drivers/install drivers.bat
@@ -58,6 +58,8 @@ wdi-simple --vid 0x0F30 --pid 0x0202 --type 0 --name "Joytech Advanced Controlle
 wdi-simple --vid 0x0F30 --pid 0x8888 --type 0 --name "BigBen XBMiniPad Controller"
 wdi-simple --vid 0x102C --pid 0xFF0C --type 0 --name "Joytech Wireless Advanced Controller"
 wdi-simple --vid 0x0738 --pid 0x4522 --type 0 --name "MadCatz LumiCON"
+wdi-simple --vid 0x12AB --pid 0x0004 --type 0 --name "Konami DDR Pad"
+wdi-simple --vid 0x12AB --pid 0x8809 --type 0 --name "Konami DDR Pad"
 wdi-simple --vid 0xFFFF --pid 0xFFFF --type 0 --name "PowerWave Xbox Controller"
 
 echo Driver installation complete!


### PR DESCRIPTION
Support for connecting to Konami DDR Pad, using this change I was able to connect, remap direction pad to other buttons (needed because many songs require multiple directions at once) and play Project Outfox (a fork of StepMania).

The pad seems to send messages with non-zero report ids and zero sizes, so I had to filter those out or the pad would repeatedly disconnect. Once that was fixed, the logic to check the return of `libusb_interrupt_transfer` needed to be checked more precisely to fail on error unless the error indicates a timeout.

Also added some code to pass through the LED setting to the controller, it was distracting to have it blinking non-stop.

Unfortunately, I don't have any other wired controllers to test with.