### PR TITLE
Add HORI Dead Or Alive 3 arcade pad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Xb2XInput - user-mode Xbox OG controller driver for Windows
+## Xb2XInput fork - user-mode Xbox OG controller driver for Windows with new devices added
 
 Xb2XInput is a small application that can translate the input from an Xbox OG controller over to a virtual XInput/DirectInput device for games to make use of, without needing any unsigned drivers to be installed!
 
@@ -19,7 +19,7 @@ While it's not fully user-mode as it needs the ViGEmBus driver to be installed, 
 - Not tied to Xbox - can be used to add support for pretty much any kind of controller
 - Signed!
 
-This fork has new devices added. Check XboxController.cpp in the patch-1 branch. New additions are marked with (NEW) on the end.
+This fork has new devices added. Check the corresponding section of the readme.md to see the list of additions.
 
 Setup
 ---
@@ -87,6 +87,10 @@ For a list of all supported controllers see the top section of [XboxController.c
 While a controller might be supported that doesn't mean it's been tested or works, the majority should hopefully all work without problem, but there could be some edge cases.
 
 If you have any issues, or have a controller that isn't on this list, please make an issue on the issues page (including the hardware ID, see Support section above)
+
+NEW SUPPORTED PERIPHERALS
+---
+- Dead or Alive 3 Hori Arcade Stick (HORI DEAD OR ALIVE 3 STICK)
 
 Thanks
 ---

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ If you have any issues, or have a controller that isn't on this list, please mak
 
 NEW SUPPORTED PERIPHERALS
 ---
-- HORI DEAD OR ALIVE 3 STICK ![HORI DEAD OR ALIVE 3 STICK](https://static.wikia.nocookie.net/deadoralive/images/4/45/Xbox_stickk.jpg/revision/latest?cb=20150219140829)
+![HORI DEAD OR ALIVE 3 STICK](https://static.wikia.nocookie.net/deadoralive/images/4/45/Xbox_stickk.jpg/revision/latest?cb=20150219140829)
+- HORI DEAD OR ALIVE 3 STICK
 
 Thanks
 ---

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ While it's not fully user-mode as it needs the ViGEmBus driver to be installed, 
 - Not tied to Xbox - can be used to add support for pretty much any kind of controller
 - Signed!
 
+This fork has new devices added. Check XboxController.cpp in the patch-1 branch. New additions are marked with (NEW) on the end.
+
 Setup
 ---
 Download the latest compiled version of Xb2XInput from the [releases page](https://github.com/emoose/Xb2XInput/releases).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you have any issues, or have a controller that isn't on this list, please mak
 
 NEW SUPPORTED PERIPHERALS
 ---
-- Dead or Alive 3 Hori Arcade Stick (HORI DEAD OR ALIVE 3 STICK)
+- HORI DEAD OR ALIVE 3 STICK ![HORI DEAD OR ALIVE 3 STICK](https://static.wikia.nocookie.net/deadoralive/images/4/45/Xbox_stickk.jpg/revision/latest?cb=20150219140829)
 
 Thanks
 ---

--- a/Xb2XInput/Xb2XInput.cpp
+++ b/Xb2XInput/Xb2XInput.cpp
@@ -10,7 +10,8 @@
 // how many times to check the USB device each second, must be 1000 or lower, higher value = higher CPU usage
 // 144 seems a good value, i don't really know anyone that uses a higher refresh rate than that...
 // TODO: make this configurable?
-const int poll_rate = 144;
+// By Cloudy Shane: Increased to 600. Why not?
+const int poll_rate = 600;
 
 int poll_ms = (1000 / min(1000, poll_rate));
 

--- a/Xb2XInput/XboxController.cpp
+++ b/Xb2XInput/XboxController.cpp
@@ -48,9 +48,19 @@ std::vector<std::pair<int, int>> xbox_devices =
   {0x0F30, 0x0202}, // Joytech Advanced Controller
   {0x0F30, 0x8888}, // BigBen XBMiniPad Controller
   {0x102C, 0xFF0C}, // Joytech Wireless Advanced Controller
+  {0xFFFF, 0xFFFF}, // PowerWave Xbox Controller (The ID's may look sketchy but this controller actually uses it)
+  // NEW ONES IN FORK:
   {0x0F0D, 0x0001}, // HORI DEAD OR ALIVE 3 STICK (NEW, tested & works)
   {0x3767, 0x0101}, // Fanatec Speedster 3 ForceShock Steering Wheel (NEW, not tested)
-  {0xFFFF, 0xFFFF}, // PowerWave Xbox Controller (The ID's may look sketchy but this controller actually uses it)
+  {0x044F, 0x0F00}, // Thrustmaster Wheel (NEW, not tested)
+  {0x044F, 0x0F03}, // Thrustmaster Wheel (NEW, not tested)
+  {0x044F, 0x0F10}, // Thrustmaster Modena GT (NEW, not tested)
+  {0x046D, 0xC181}, // Logitech Precision Vibration Feedback Wheel (NEW, not tested)
+  {0x062A, 0x0033}, // Competition Pro Steering Wheel (NEW, not tested)
+  {0x06A3, 0x0200}, // Saitek Racingwheel (NEW, not tested)
+  {0x0738, 0x4530}, // Mad Catz Universal MC2™ Racing Wheel and Pedals (NEW, not tested)
+  {0x0E8F, 0x0201}, // Gamexpert PS2/GC/Xbox Steering Wheel (NEW, not tested)
+
 };
 
 UserSettings defaults_;

--- a/Xb2XInput/XboxController.cpp
+++ b/Xb2XInput/XboxController.cpp
@@ -48,7 +48,8 @@ std::vector<std::pair<int, int>> xbox_devices =
   {0x0F30, 0x0202}, // Joytech Advanced Controller
   {0x0F30, 0x8888}, // BigBen XBMiniPad Controller
   {0x102C, 0xFF0C}, // Joytech Wireless Advanced Controller
-  {0x0F0D, 0x0001}, // HORI DEAD OR ALIVE 3 STICK (NEW)
+  {0x0F0D, 0x0001}, // HORI DEAD OR ALIVE 3 STICK (NEW, tested & works)
+  {0x3767, 0x0101}, // Fanatec Speedster 3 ForceShock Steering Wheel (NEW, not tested)
   {0xFFFF, 0xFFFF}, // PowerWave Xbox Controller (The ID's may look sketchy but this controller actually uses it)
 };
 

--- a/Xb2XInput/XboxController.cpp
+++ b/Xb2XInput/XboxController.cpp
@@ -48,6 +48,7 @@ std::vector<std::pair<int, int>> xbox_devices =
   {0x0F30, 0x0202}, // Joytech Advanced Controller
   {0x0F30, 0x8888}, // BigBen XBMiniPad Controller
   {0x102C, 0xFF0C}, // Joytech Wireless Advanced Controller
+  {0x0F0D, 0x0001}, // HORI Dead Or Alive 3 Arcade Pad
   {0xFFFF, 0xFFFF}, // PowerWave Xbox Controller (The ID's may look sketchy but this controller actually uses it)
 };
 

--- a/Xb2XInput/XboxController.cpp
+++ b/Xb2XInput/XboxController.cpp
@@ -48,7 +48,7 @@ std::vector<std::pair<int, int>> xbox_devices =
   {0x0F30, 0x0202}, // Joytech Advanced Controller
   {0x0F30, 0x8888}, // BigBen XBMiniPad Controller
   {0x102C, 0xFF0C}, // Joytech Wireless Advanced Controller
-  {0x0F0D, 0x0001}, // HORI Dead Or Alive 3 Arcade Pad (NEW)
+  {0x0F0D, 0x0001}, // HORI DEAD OR ALIVE 3 STICK (NEW)
   {0xFFFF, 0xFFFF}, // PowerWave Xbox Controller (The ID's may look sketchy but this controller actually uses it)
 };
 

--- a/Xb2XInput/XboxController.cpp
+++ b/Xb2XInput/XboxController.cpp
@@ -48,7 +48,7 @@ std::vector<std::pair<int, int>> xbox_devices =
   {0x0F30, 0x0202}, // Joytech Advanced Controller
   {0x0F30, 0x8888}, // BigBen XBMiniPad Controller
   {0x102C, 0xFF0C}, // Joytech Wireless Advanced Controller
-  {0x0F0D, 0x0001}, // HORI Dead Or Alive 3 Arcade Pad
+  {0x0F0D, 0x0001}, // HORI Dead Or Alive 3 Arcade Pad (NEW)
   {0xFFFF, 0xFFFF}, // PowerWave Xbox Controller (The ID's may look sketchy but this controller actually uses it)
 };
 


### PR DESCRIPTION
I have added support for HORI DEAD OR ALIVE 3 STICK and tested it. It works.